### PR TITLE
Test fixes for shared http client changes

### DIFF
--- a/test/clj_puppetdb/core_test.clj
+++ b/test/clj_puppetdb/core_test.clj
@@ -3,49 +3,50 @@
             [clj-puppetdb.core :refer :all]
             [clj-puppetdb.http-core :refer :all]
             [clj-puppetdb.http :refer [GET]]
-            [puppetlabs.http.client.sync :as http]))
+            [puppetlabs.http.client.sync :as http]
+            [puppetlabs.http.client.async :as async]))
 
 (deftest connect-test
-  (testing "Should create a connection with http://localhost:8080 with no additional arguments"
-    (let [conn (connect "http://localhost:8080")]
-      (is (= (client-info conn) {:host "http://localhost:8080"}))))
-  (testing "Should create a connection with http://localhost:8080 and VCR enabled"
-    (let [conn (connect "http://localhost:8080" {:vcr-dir "/temp"})]
-      (is (= (client-info conn) {:host "http://localhost:8080" :vcr-dir "/temp"}))))
-  (testing "Should accept https://puppetdb:8081 with a map of test certs"
-    (let [opts {:ssl-ca-cert "./dev-resources/certs/ca-cert.pem"
-                :ssl-cert    "./dev-resources/certs/cert.pem"
-                :ssl-key     "./dev-resources/certs/key.pem"}
-          conn (connect "https://puppetdb:8081" opts)]
-      ;; I'm only testing for truthiness of conn here. Schema validation should handle the rest,
-      ;; and testing equality with java.io.File objects doesn't seem to work.
-      (is conn)))
-  (testing "Should accept https://puppetdb:8081 with a map of test certs and VCR enabled"
-    (let [opts {:ssl-ca-cert "./dev-resources/certs/ca-cert.pem"
-                :ssl-cert    "./dev-resources/certs/cert.pem"
-                :ssl-key     "./dev-resources/certs/key.pem"
-                :vcr-dir     "/temp"}
-          conn (connect "https://puppetdb:8081" opts)]
-      ;; I'm testing for truthiness of conn here. Schema validation should handle the rest except the VCR piece,
-      ;; and testing equality with java.io.File objects doesn't seem to work.
-      (is conn)
-      (is (= (:vcr-dir opts) (:vcr-dir (client-info conn))))
-      (is (:ssl-context (client-info conn)))))
-  (testing "SSL connection should require certificates"
-    (is (thrown? IllegalArgumentException (connect "https://puppetdb:8081" {})))
-    (is (thrown? IllegalArgumentException (connect "https://puppetdb:8081"
-                                                   {:ssl-context "dummy"})))
-    (is (thrown? IllegalArgumentException (connect "https://puppetdb:8081"
-                                                   {:ssl-cert "dummy" :ssl-key "dummy" :ssl-ca-cert "dummy"}))))
-  (testing "Should do proper GET request"
-    (let [host "http://localhost:8080"
-          path "/v4/nodes"
-          params {:query [:= [:fact "operatingsystem"] "Linux"]}
-          url-params "?query=%5B%22%3D%22%2C%5B%22fact%22%2C%22operatingsystem%22%5D%2C%22Linux%22%5D"
-          conn (connect host)]
-      (with-redefs [http/get (fn[query _] (is (= query (str host path url-params))) [])]
-        (pdb-get conn path params)
-        (pdb-do-get conn (str host path url-params))))))
+  (let [http-client (async/create-client {})]
+    (testing "Should create a connection with http://localhost:8080 with no additional arguments"
+      (let [conn (connect http-client "http://localhost:8080")]
+        (is (= (client-info conn) {:host "http://localhost:8080"}))))
+    (testing "Should create a connection with http://localhost:8080 and VCR enabled"
+      (let [conn (connect http-client "http://localhost:8080" {:vcr-dir "/temp"})]
+        (is (= (client-info conn) {:host "http://localhost:8080" :vcr-dir "/temp"}))))
+    (testing "Should accept https://puppetdb:8081 with a map of test certs"
+      (let [opts {:ssl-ca-cert "./dev-resources/certs/ca-cert.pem"
+                  :ssl-cert    "./dev-resources/certs/cert.pem"
+                  :ssl-key     "./dev-resources/certs/key.pem"}
+            conn (connect http-client "https://puppetdb:8081" opts)]
+        ;; I'm only testing for truthiness of conn here. Schema validation should handle the rest,
+        ;; and testing equality with java.io.File objects doesn't seem to work.
+        (is conn)))
+    (testing "Should accept https://puppetdb:8081 with a map of test certs and VCR enabled"
+      (let [opts {:ssl-ca-cert "./dev-resources/certs/ca-cert.pem"
+                  :ssl-cert    "./dev-resources/certs/cert.pem"
+                  :ssl-key     "./dev-resources/certs/key.pem"
+                  :vcr-dir     "/temp"}
+            conn (connect http-client "https://puppetdb:8081" opts)]
+        ;; I'm testing for truthiness of conn here. Schema validation should handle the rest except the VCR piece,
+        ;; and testing equality with java.io.File objects doesn't seem to work.
+        (is conn)
+        (is (= (:vcr-dir opts) (:vcr-dir (client-info conn))))
+        (is (:ssl-context (client-info conn)))))
+    (testing "SSL connection should require certificates"
+      (is (thrown? IllegalArgumentException (connect http-client "https://puppetdb:8081" {})))
+      (is (thrown? IllegalArgumentException (connect http-client "https://puppetdb:8081" {:ssl-context "dummy"})))
+      (is (thrown? IllegalArgumentException (connect http-client "https://puppetdb:8081"
+                                                     {:ssl-cert "dummy" :ssl-key "dummy" :ssl-ca-cert "dummy"}))))
+    (testing "Should do proper GET request"
+      (let [host "http://localhost:8080"
+            path "/v4/nodes"
+            params {:query [:= [:fact "operatingsystem"] "Linux"]}
+            url-params "?query=%5B%22%3D%22%2C%5B%22fact%22%2C%22operatingsystem%22%5D%2C%22Linux%22%5D"
+            conn (connect http-client host)]
+        (with-redefs [http/get (fn [query _] (is (= query (str host path url-params))) [])]
+          (pdb-get conn path params)
+          (pdb-do-get conn (str host path url-params)))))))
 
 (deftest query-test
   (let [data ["node-01" "node-02" "node-03" "node-04"]

--- a/test/clj_puppetdb/http_test.clj
+++ b/test/clj_puppetdb/http_test.clj
@@ -4,7 +4,7 @@
             [clj-puppetdb.http :refer [GET make-client]]
             [clj-puppetdb.http-core :refer :all]
             [cheshire.core :as json]
-            [puppetlabs.http.client.async :as async])
+            [puppetlabs.http.client.async :as http])
   (:import [clojure.lang ExceptionInfo]))
 
 (defn- test-query-params
@@ -25,42 +25,43 @@
     (pdb-get wrapped-client "" params)))
 
 (deftest parameter-encoding-test
-  (let [client (make-client "http://localhost:8080" {})]
-    (testing "Should JSON encode parameters which requre it"
-      (test-query-params client {:foo           [:bar "baz"]
-                                 :counts_filter [:> "failures" 0]
-                                 :query         [:= :certname "node"]
-                                 :order_by      [{:field "status" :order "ASC"}]}
-                         #(is (= % "http://localhost:8080?counts_filter=%5B%22%3E%22%2C%22failures%22%2C0%5D&foo=%5B%3Abar%20%22baz%22%5D&order_by=%5B%7B%22field%22%3A%22status%22%2C%22order%22%3A%22ASC%22%7D%5D&query=%5B%22%3D%22%2C%22certname%22%2C%22node%22%5D"))))
-    (testing "Should leave already encoded params alone"
-      (test-query-params client {:order_by      "[{\"order\":\"ASC\",\"field\":\"status\"}]"}
-                         #(is (= % "http://localhost:8080?order_by=%5B%7B%22order%22%3A%22ASC%22%2C%22field%22%3A%22status%22%7D%5D")))))
-  (let [client (make-client "http://localhost:8080" {:vcr-dir "foo"})]
-    (testing "Should sort parameters contianing nested structures"
-      (test-query-params client {:order_by      [{:order "ASC" :field "status"}]}
-                         #(is (= % "http://localhost:8080?order_by=%5B%7B%22field%22%3A%22status%22%2C%22order%22%3A%22ASC%22%7D%5D"))))
-    (testing "Should sort parameters contianing nested structures even if already JSON encoded"
-      (test-query-params client {:order_by      "[{\"order\":\"ASC\",\"field\":\"status\"}]"}
-                         #(is (= % "http://localhost:8080?order_by=%5B%7B%22field%22%3A%22status%22%2C%22order%22%3A%22ASC%22%7D%5D"))))))
+  (let [http-client (http/create-client {})]
+    (let [client (make-client http-client "http://localhost:8080" {})]
+      (testing "Should JSON encode parameters which requre it"
+        (test-query-params client {:foo           [:bar "baz"]
+                                   :counts_filter [:> "failures" 0]
+                                   :query         [:= :certname "node"]
+                                   :order_by      [{:field "status" :order "ASC"}]}
+                           #(is (= % "http://localhost:8080?counts_filter=%5B%22%3E%22%2C%22failures%22%2C0%5D&foo=%5B%3Abar%20%22baz%22%5D&order_by=%5B%7B%22field%22%3A%22status%22%2C%22order%22%3A%22ASC%22%7D%5D&query=%5B%22%3D%22%2C%22certname%22%2C%22node%22%5D"))))
+      (testing "Should leave already encoded params alone"
+        (test-query-params client {:order_by "[{\"order\":\"ASC\",\"field\":\"status\"}]"}
+                           #(is (= % "http://localhost:8080?order_by=%5B%7B%22order%22%3A%22ASC%22%2C%22field%22%3A%22status%22%7D%5D")))))
+    (let [client (make-client http-client "http://localhost:8080" {:vcr-dir "foo"})]
+      (testing "Should sort parameters contianing nested structures"
+        (test-query-params client {:order_by [{:order "ASC" :field "status"}]}
+                           #(is (= % "http://localhost:8080?order_by=%5B%7B%22field%22%3A%22status%22%2C%22order%22%3A%22ASC%22%7D%5D"))))
+      (testing "Should sort parameters contianing nested structures even if already JSON encoded"
+        (test-query-params client {:order_by "[{\"order\":\"ASC\",\"field\":\"status\"}]"}
+                           #(is (= % "http://localhost:8080?order_by=%5B%7B%22field%22%3A%22status%22%2C%22order%22%3A%22ASC%22%7D%5D")))))))
 
 (deftest GET-test
   (let [host "http://localhost:8080"
         path "/v4/nodes"
         params {:query [:= [:fact "operatingsystem"] "Linux"]}
-        client (make-client host {})
+        client (make-client (http/create-client {}) host {})
         response-data ["node-1" "node-2"]
         response-data-encoded (json/encode response-data)
         response-headers {"x-records" (.toString (count response-data))}
         fake-get (fn[status] {:status status :body (io/input-stream (.getBytes response-data-encoded)) :headers response-headers})]
 
       (testing "Should have proper response"
-        (with-redefs [async/request-with-client (fn[_ _ _] (future (fake-get 200)))]
+        (with-redefs [http/request-with-client (fn[_ _ _] (future (fake-get 200)))]
           (let [GET-response (GET client path params)]
             (is (= (first GET-response) response-data))
             (is (= (second GET-response) response-headers)))))
 
       (testing "Should throw proper exception"
-        (with-redefs [async/request-with-client (fn[_ _ _] (future (fake-get 400)))]
+        (with-redefs [http/request-with-client (fn[_ _ _] (future (fake-get 400)))]
           (try
             (GET client path params)
             (catch ExceptionInfo ei

--- a/test/clj_puppetdb/vcr_test.clj
+++ b/test/clj_puppetdb/vcr_test.clj
@@ -23,10 +23,11 @@
 
 (deftest vcr-test
   (testing "VCR recording and replay"
-    (let [vcr-dir "vcr-test"]
+    (let [vcr-dir "vcr-test"
+          http-client (async/create-client {})]
       (fs/delete-dir vcr-dir)
       (testing "when VCR is enabled"
-        (let [conn (connect "http://localhost:8080" {:vcr-dir vcr-dir})]
+        (let [conn (connect http-client "http://localhost:8080" {:vcr-dir vcr-dir})]
           (is (= vcr-dir (:vcr-dir (client-info conn))))
           (testing "and no recording exists"
             (with-redefs [async/request-with-client
@@ -93,7 +94,7 @@
                                                             [:= :certname "test"]
                                                             (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))))
         (testing "when VCR is not enabled but a recording exists"
-          (let [conn (connect "http://localhost:8080")]
+          (let [conn (connect http-client "http://localhost:8080")]
             (is (not (contains? (client-info conn) :vcr-dir)))
             (with-redefs [async/request-with-client
                           (fn [_ _ _] (future


### PR DESCRIPTION
Additional parm for http-client within the unit tests fix. Try to ignore the whitespace which are a side effect of large let block indents.
